### PR TITLE
fix: update timeouts to 60 seconds to match Gr4vy timeout specs

### DIFF
--- a/src/main/java/com/gr4vy/api/ApiClient.java
+++ b/src/main/java/com/gr4vy/api/ApiClient.java
@@ -112,6 +112,9 @@ public class ApiClient {
     private void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
+        builder.connectTimeout(60, TimeUnit.SECONDS);
+        builder.readTimeout(60, TimeUnit.SECONDS);
+        builder.writeTimeout(60, TimeUnit.SECONDS);
         for (Interceptor interceptor: interceptors) {
             builder.addInterceptor(interceptor);
         }


### PR DESCRIPTION
This update extends the timeout range to 60 seconds to match Gr4vy timeouts