### PR TITLE
fix: re-add client timeout

### DIFF
--- a/src/main/java/com/gr4vy/api/ApiClient.java
+++ b/src/main/java/com/gr4vy/api/ApiClient.java
@@ -112,6 +112,9 @@ public class ApiClient {
     private void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
+        builder.connectTimeout(60, TimeUnit.SECONDS);
+        builder.readTimeout(60, TimeUnit.SECONDS);
+        builder.writeTimeout(60, TimeUnit.SECONDS);
         for (Interceptor interceptor: interceptors) {
             builder.addInterceptor(interceptor);
         }


### PR DESCRIPTION
This PR adds the 60 second timeout for the java SDK client.