### PR TITLE
fix: add bolivia/multipago support

### DIFF
--- a/src/main/java/com/gr4vy/api/model/TaxId.java
+++ b/src/main/java/com/gr4vy/api/model/TaxId.java
@@ -48,6 +48,8 @@ public class TaxId {
     AR_CUIL("ar.cuil"),
     
     AR_CUIT("ar.cuit"),
+
+    BO_CI("bo.ci"),
     
     BR_CNPJ("br.cnpj"),
     

--- a/src/main/java/com/gr4vy/api/model/Transaction.java
+++ b/src/main/java/com/gr4vy/api/model/Transaction.java
@@ -485,6 +485,8 @@ public class Transaction {
     GRABPAY("grabpay"),
     
     KLARNA("klarna"),
+
+    MULTIPAGO("multipago"),
     
     OVO("ovo"),
     


### PR DESCRIPTION
This hotfix adds support for Bolivia tax id and multipago payment service. Full update for new spec incoming.