### PR TITLE
feat: Add merchant account ID header to all requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ Gr4vyClient gr4vyClient = new Gr4vyClient("[YOUR_GR4VY_ID]", "private_key.pem", 
 
 ```
 
+## Multi merchant
+
+In a multi-merchant environment, the merchant account ID can be set after the SDK has been initialized.
+
+```java
+gr4vyClient.setMerchantAccountId("my-account-id"); // defaults to `default`
+```
+
 ## Gr4vy Embed
 
 To create a token for Gr4vy Embed, call the `client.getEmbedToken(embed)`

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>gr4vy</artifactId>
     <packaging>jar</packaging>
     <name>gr4vy</name>
-    <version>0.12.0</version>
+    <version>0.13.0</version>
     <url>https://gr4vy.com</url>
     <description>Gr4vy Java SDK</description>
 

--- a/src/main/java/com/gr4vy/sdk/Gr4vyClient.java
+++ b/src/main/java/com/gr4vy/sdk/Gr4vyClient.java
@@ -46,6 +46,7 @@ public class Gr4vyClient {
 	private String host;
 	private String environment;
 	private Boolean debug = false;
+	private String merchantAccountId = 'default'
 
     /**
      * Constructor
@@ -77,6 +78,10 @@ public class Gr4vyClient {
         this.host = "https://api." + apiPrefix + gr4vyId  + ".gr4vy.app";
         this.debug = debug;
     }
+
+	public void setMerchantAccountId(String merchantAccountId) {
+    	this.merchantAccountId = merchantAccountId;
+    }
 	
     public void setHost(String host) {
     	this.host = host;
@@ -85,6 +90,7 @@ public class Gr4vyClient {
 		try {
 			ApiClient defaultClient = Configuration.getDefaultApiClient();
 			defaultClient.setBasePath(this.host);
+			defaultClient.addDefaultHeader("X-GR4VY-MERCHANT-ACCOUNT-ID", this.merchantAccountId)
 
 			String key = getKey();
 			

--- a/src/main/java/com/gr4vy/sdk/Gr4vyClient.java
+++ b/src/main/java/com/gr4vy/sdk/Gr4vyClient.java
@@ -46,7 +46,7 @@ public class Gr4vyClient {
 	private String host;
 	private String environment;
 	private Boolean debug = false;
-	private String merchantAccountId = 'default'
+	private String merchantAccountId = 'default';
 
     /**
      * Constructor
@@ -79,7 +79,7 @@ public class Gr4vyClient {
         this.debug = debug;
     }
 
-	public void setMerchantAccountId(String merchantAccountId) {
+    public void setMerchantAccountId(String merchantAccountId) {
     	this.merchantAccountId = merchantAccountId;
     }
 	
@@ -90,7 +90,7 @@ public class Gr4vyClient {
 		try {
 			ApiClient defaultClient = Configuration.getDefaultApiClient();
 			defaultClient.setBasePath(this.host);
-			defaultClient.addDefaultHeader("X-GR4VY-MERCHANT-ACCOUNT-ID", this.merchantAccountId)
+			defaultClient.addDefaultHeader("X-GR4VY-MERCHANT-ACCOUNT-ID", this.merchantAccountId);
 
 			String key = getKey();
 			

--- a/src/main/java/com/gr4vy/sdk/Gr4vyClient.java
+++ b/src/main/java/com/gr4vy/sdk/Gr4vyClient.java
@@ -46,7 +46,7 @@ public class Gr4vyClient {
 	private String host;
 	private String environment;
 	private Boolean debug = false;
-	private String merchantAccountId = 'default';
+	private String merchantAccountId = "default";
 
     /**
      * Constructor


### PR DESCRIPTION
Re TA-4184 - Adds an optional `merchantAccountId` setter to the client for use with multi merchant. This sets the `X-GR4VY-MERCHANT-ACCOUNT-ID` header and defaults to the `default` ID.