### PR TITLE
feat(auth): add configurable expiration time to tokens (CHIPS-505)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>gr4vy</artifactId>
     <packaging>jar</packaging>
     <name>gr4vy</name>
-    <version>0.18.0</version>
+    <version>0.19.0</version>
     <url>https://gr4vy.com</url>
     <description>Gr4vy Java SDK</description>
 

--- a/src/main/java/com/gr4vy/sdk/Gr4vyClient.java
+++ b/src/main/java/com/gr4vy/sdk/Gr4vyClient.java
@@ -147,14 +147,14 @@ public class Gr4vyClient {
 	}
 	
 	public String getToken(String key, String[] scopes, Map<String, Object> embed) throws IOException, NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException, JOSEException, ParseException {
-		return getToken(key, scopes, embed, null, 60);
+		return getToken(key, scopes, embed, null, 60000);
 	}
 	
 	public String getToken(String key, String[] scopes, Map<String, Object> embed, UUID checkoutSessionId) throws IOException, NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException, JOSEException, ParseException {
-		return getToken(key, scopes, embed, checkoutSessionId, 60);
+		return getToken(key, scopes, embed, checkoutSessionId, 60000);
 	}
 
-	public String getToken(String key, String[] scopes, Map<String, Object> embed, UUID checkoutSessionId, int tokenExpirySeconds) throws IOException, NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException, JOSEException, ParseException {
+	public String getToken(String key, String[] scopes, Map<String, Object> embed, UUID checkoutSessionId, int tokenExpiryMillis) throws IOException, NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException, JOSEException, ParseException {
 		Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
 		
 		Reader reader = new StringReader(key);
@@ -171,7 +171,7 @@ public class Gr4vyClient {
 	    JWSSigner signer = new ECDSASigner(e);
 	    
 	    Date now = new Date();
-	    Date expire = new Date(now.getTime() + tokenExpirySeconds * 1000);
+	    Date expire = new Date(now.getTime() + tokenExpiryMillis);
 	    
 	    JWTClaimsSet.Builder claimsSet = new JWTClaimsSet.Builder()
 	    		.jwtID(UUID.randomUUID().toString())

--- a/src/main/java/com/gr4vy/sdk/Gr4vyClient.java
+++ b/src/main/java/com/gr4vy/sdk/Gr4vyClient.java
@@ -147,10 +147,14 @@ public class Gr4vyClient {
 	}
 	
 	public String getToken(String key, String[] scopes, Map<String, Object> embed) throws IOException, NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException, JOSEException, ParseException {
-		return getToken(key, scopes, embed, null);
+		return getToken(key, scopes, embed, null, 60);
+	}
+	
+	public String getToken(String key, String[] scopes, Map<String, Object> embed, UUID checkoutSessionId) throws IOException, NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException, JOSEException, ParseException {
+		return getToken(key, scopes, embed, checkoutSessionId, 60);
 	}
 
-	public String getToken(String key, String[] scopes, Map<String, Object> embed, UUID checkoutSessionId) throws IOException, NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException, JOSEException, ParseException {
+	public String getToken(String key, String[] scopes, Map<String, Object> embed, UUID checkoutSessionId, int tokenExpirySeconds) throws IOException, NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException, JOSEException, ParseException {
 		Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
 		
 		Reader reader = new StringReader(key);
@@ -167,13 +171,13 @@ public class Gr4vyClient {
 	    JWSSigner signer = new ECDSASigner(e);
 	    
 	    Date now = new Date();
-	    Date expire = new Date(now.getTime() + 60 * 1000);
+	    Date expire = new Date(now.getTime() + tokenExpirySeconds * 1000);
 	    
 	    JWTClaimsSet.Builder claimsSet = new JWTClaimsSet.Builder()
 	    		.jwtID(UUID.randomUUID().toString())
 	    		.notBeforeTime(now)
 	    	    .issueTime(now)
-	    	    .issuer("Gr4vy SDK 0.1.0 - Java")
+	    	    .issuer("Gr4vy SDK 0.19.0 - Java")
 	    	    .expirationTime(expire)
 	    	    .claim("scopes", scopes);
 	    

--- a/src/test/java/com/gr4vy/sdk/Gr4vyClientTest.java
+++ b/src/test/java/com/gr4vy/sdk/Gr4vyClientTest.java
@@ -74,7 +74,7 @@ public class Gr4vyClientTest {
 		
 		String key = client.getKey();
 		String[] scopes = {"*.read", "*.write"};
-		String token = client.getToken(key, scopes, null, null, 900);
+		String token = client.getToken(key, scopes, null, null, 900000);
 		
         assert token != null;
     }

--- a/src/test/java/com/gr4vy/sdk/Gr4vyClientTest.java
+++ b/src/test/java/com/gr4vy/sdk/Gr4vyClientTest.java
@@ -69,6 +69,17 @@ public class Gr4vyClientTest {
     }
 	
 	@Test
+    public void getTokenTestWithTokenExpiry() throws Gr4vyException, NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException, IOException, JOSEException, ParseException {
+    	Gr4vyClient client = new Gr4vyClient("spider", "private_key.pem", "sandbox");
+		
+		String key = client.getKey();
+		String[] scopes = {"*.read", "*.write"};
+		String token = client.getToken(key, scopes, null, null, 900);
+		
+        assert token != null;
+    }
+	
+	@Test
 	public void addBuyersTest() throws Gr4vyException {
 		Gr4vyClient client = new Gr4vyClient("spider", "private_key.pem", "sandbox");
      	BuyerRequest buyer = new BuyerRequest();


### PR DESCRIPTION
Re CHIPS-505

Currently the `getToken` call creates tokens with an expiration time of 60 second. This change introduces an optional parameter to set a custom expiration time for a token.