### PR TITLE
test: cover API key pairs and transaction refund-settlements endpoints

### DIFF
--- a/src/test/java/com/gr4vy/sdk/backoffice/ApiKeyPairsTest.java
+++ b/src/test/java/com/gr4vy/sdk/backoffice/ApiKeyPairsTest.java
@@ -1,0 +1,85 @@
+package com.gr4vy.sdk.backoffice;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import com.gr4vy.sdk.Gr4vy;
+import com.gr4vy.sdk.models.components.APIKeyPairCreate;
+import com.gr4vy.sdk.models.components.APIKeyPairUpdate;
+import com.gr4vy.sdk.util.Fixtures;
+import com.gr4vy.sdk.util.Harness;
+import com.gr4vy.sdk.util.Reaches;
+
+/**
+ * E2E coverage for the API key pairs endpoints. Listing is supported by the
+ * sandbox and asserted as a real 2xx. Create, get, update and delete each need
+ * a real key pair (and, for create, a real role) that the deterministic mock
+ * environment does not provide, so they are asserted via {@link Reaches}: a 4xx
+ * means the SDK built a correct request and the API routed and rejected it,
+ * which is exactly the "endpoint reached" signal the coverage check needs.
+ *
+ * <p>API key pairs are an account-level resource, like merchant accounts. Those
+ * endpoints ignore the per-request merchant scope, so — mirroring
+ * {@link MerchantAccountsTest} — the shared merchant-bound {@link Harness#client()}
+ * is used directly rather than a separate admin client.
+ */
+class ApiKeyPairsTest {
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "E2E", matches = "true")
+    void list() throws Exception {
+        Gr4vy client = Harness.client();
+        assertNotNull(client.apiKeyPairs().list().call());
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "E2E", matches = "true")
+    void create() {
+        Gr4vy client = Harness.client();
+        // A nonexistent role id makes the API reject the request with a 4xx while
+        // still routing to the create endpoint.
+        Reaches.reaches("apiKeyPairs.create", () -> client.apiKeyPairs().create()
+                .request(APIKeyPairCreate.builder()
+                        .displayName("E2E api key pair")
+                        .roleIds(List.of(Fixtures.MISSING_ID))
+                        .build())
+                .call());
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "E2E", matches = "true")
+    void get() {
+        Gr4vy client = Harness.client();
+        // A nonexistent id yields a 4xx: the get endpoint was reached.
+        Reaches.reaches("apiKeyPairs.get", () -> client.apiKeyPairs().get()
+                .apiKeyPairId(Fixtures.MISSING_ID)
+                .call());
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "E2E", matches = "true")
+    void update() {
+        Gr4vy client = Harness.client();
+        // A nonexistent id yields a 4xx: the update endpoint was reached.
+        Reaches.reaches("apiKeyPairs.update", () -> client.apiKeyPairs().update()
+                .apiKeyPairId(Fixtures.MISSING_ID)
+                .apiKeyPairUpdate(APIKeyPairUpdate.builder()
+                        .displayName("E2E api key pair")
+                        .build())
+                .call());
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "E2E", matches = "true")
+    void delete() {
+        Gr4vy client = Harness.client();
+        // A nonexistent id yields a 4xx: the delete endpoint was reached.
+        Reaches.reaches("apiKeyPairs.delete", () -> client.apiKeyPairs().delete()
+                .apiKeyPairId(Fixtures.MISSING_ID)
+                .call());
+    }
+}

--- a/src/test/java/com/gr4vy/sdk/processing/TransactionsTest.java
+++ b/src/test/java/com/gr4vy/sdk/processing/TransactionsTest.java
@@ -143,6 +143,27 @@ class TransactionsTest {
 
     @Test
     @EnabledIfEnvironmentVariable(named = "E2E", matches = "true")
+    void refundSettlements() throws Exception {
+        Gr4vy client = Harness.client();
+        Transaction t = createApprovedTransaction(client);
+
+        // Listing refund settlements for a real transaction is a happy path.
+        assertNotNull(client.transactions().refundSettlements().list()
+                .transactionId(t.id())
+                .call());
+
+        // A specific refund settlement needs a settled refund the deterministic
+        // mock cannot force, so a missing id reaching a 4xx confirms the get
+        // endpoint was routed to and reached.
+        Reaches.reaches("get transaction refund settlement (missing)", () ->
+                client.transactions().refundSettlements().get()
+                        .transactionId(t.id())
+                        .settlementId(Fixtures.MISSING_ID)
+                        .call());
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "E2E", matches = "true")
     void refunds() throws Exception {
         Gr4vy client = Harness.client();
         Transaction t = createApprovedTransaction(client);


### PR DESCRIPTION
## The gap

The CI endpoint-coverage check only counts an endpoint as covered when a real HTTP request reaches the server. Two families were uncovered:

1. **API key pairs** (`src/main/java/com/gr4vy/sdk/ApiKeyPairs.java`) — create/list/get/update/delete had no tests at all.
2. **Transaction refund-settlements** — the `GET /transactions/{transaction_id}/refund-settlements` (list) and `GET /transactions/{transaction_id}/refund-settlements/{settlement_id}` (get) sub-resource endpoints (the last 2 of 116).

## The design

### API key pairs — new `src/test/java/com/gr4vy/sdk/backoffice/ApiKeyPairsTest.java`
Mirrors `PayoutsTest` / `MerchantAccountsTest`:
- **list** — happy path, asserts a real 2xx.
- **create / get / update / delete** — asserted via the repo's `Reaches` helper, using `Fixtures.MISSING_ID` for ids and a nonexistent role for create. A 4xx confirms the SDK built a correct request and the API routed to and reached the endpoint.

API key pairs are an account-level resource (like merchant accounts), whose endpoints ignore the per-request merchant scope, so — as in `MerchantAccountsTest` — the shared merchant-bound `Harness.client()` is used directly.

### Transaction refund-settlements — added `refundSettlements()` to `TransactionsTest`
Mirrors the existing `settlements()` sub-resource test:
- **list** — happy path against a live approved transaction, asserts a real 2xx.
- **get** — via `Reaches` with a missing settlement id, since a specific refund settlement needs a settled refund the deterministic mock cannot force.

All tests are gated on `E2E=true` like the rest of the live suite. `./gradlew compileTestJava` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)